### PR TITLE
update `requestentry` version to available version

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "devDependencies": {},
   "dependencies": {
-    "requestretry": "^1.12.2",
+    "requestretry": "^1.12.0",
     "debug": "^2.6.8",
     "lodash.defaults": "^4.2.0"
   },


### PR DESCRIPTION
I had mistakenly thought that `1.12.2` was the most recent published version of `requestentry`, but it is only `1.12.0`, as per its [page on npm](https://www.npmjs.com/package/requestretry). Checked the other deps and they are all correct.